### PR TITLE
Add support for OS dark mode

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -42,7 +42,12 @@ class Blipread {
       label = label + "′";
     }
 
-    this.setExtensionIcon(label);
+    var color = "#000000";
+    if ("dark" == request.schemeColor) {
+      color = "#ffffff";
+    }
+
+    this.setExtensionIcon(label, color);
   }
 
   onOptionsChange(changes, areaName) {
@@ -55,14 +60,14 @@ class Blipread {
     }
   }
 
-  setExtensionIcon(label) {
+  setExtensionIcon(label, color) {
     this.canvas.width = 32;
     this.canvas.height = 32;
 
     this.context.font = "23px Helvetica";
     this.context.textAlign = "center";
     this.context.textBaseline = "middle";
-    this.context.fillStyle = "#000000";
+    this.context.fillStyle = color;
     this.context.fillText(label, 17, 17);
 
     chrome.browserAction.setIcon({

--- a/js/background.js
+++ b/js/background.js
@@ -42,10 +42,7 @@ class Blipread {
       label = label + "′";
     }
 
-    var color = "#000000";
-    if ("dark" == request.schemeColor) {
-      color = "#ffffff";
-    }
+    var color = request.schemeColor == "dark" ? "#ffffff" : "#000000";
 
     this.setExtensionIcon(label, color);
   }

--- a/js/content.js
+++ b/js/content.js
@@ -1,2 +1,7 @@
 var contentLength = document.body.innerText.split(' ').length;
-chrome.runtime.sendMessage({contentLength: contentLength});
+var schemeColor = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+
+chrome.runtime.sendMessage({
+	contentLength: contentLength,
+	schemeColor: schemeColor,
+});


### PR DESCRIPTION
Adds support for OS dark mode:

- Gets the color mode via `matchMedia`.
- Passes a `schemeColor` variable on the message.
- Picks contrasting color depending on the OS mode.

Fixes: https://github.com/folletto/Blipread/issues/5

![2020-12-15 16 07 50](https://user-images.githubusercontent.com/390760/102240462-cb121d80-3eef-11eb-9add-91299329aa7f.gif)
